### PR TITLE
feat: add support for counting tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,22 +694,7 @@ foreach (var content in response.Value.Content)
 
 ### Prompt Caching
 
-Anthropic has recently introduced a feature called [Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) that allows you to cache all or part of the prompt you send to the model. This can be used to improve the performance of your application by reducing latency and token usage. This feature is covered in depth in [Anthropic's API Documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
-
-> [!NOTE]
-> This feature is in beta and requires you to set an `anthropic-beta` header on your requests to use it.
-> The value of the header should be `prompt-caching-2024-07-31`.
-
-When using this library you can opt-in to prompt caching by adding the required header to the `HttpClient` instance you provide to the `AnthropicApiClient` constructor.
-
-```csharp
-using AnthropicClient;
-
-var httpClient = new HttpClient();
-httpClient.DefaultRequestHeaders.Add("anthropic-beta", "prompt-caching-2024-07-31");
-
-var client = new AnthropicApiClient(apiKey, httpClient);
-```
+Anthropic provides a feature called [Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) that allows you to cache all or part of the prompt you send to the model. This can be used to improve the performance of your application by reducing latency and token usage. This feature is covered in depth in [Anthropic's API Documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
 
 Prompt caching can be used to cache all parts of the prompt including system messages, user messages, and tools. You should refer to the [Anthropic API Documentation](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) for specifics on limitations and requirements for using prompt caching. This library aims to make using prompt caching convenient and give you complete control over what parts of the prompt are cached. Currently there is only one type of cache control available - `EphemeralCacheControl`.
 
@@ -850,22 +835,7 @@ foreach (var content in response.Value.Content)
 
 ### PDF Support
 
-Anthropic has recently introduced a feature called [PDF Support](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support) that allows Claude to support PDF input and understand both text and visual content within documents. . This feature is covered in depth in [Anthropic's API Documentation](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support).
-
-> [!NOTE]
-> This feature is in beta and requires you to set an `anthropic-beta` header on your requests to use it.
-> The value of the header should be `pdfs-2024-09-25`.
-
-When using this library you can opt-in to PDF support by adding the required header to the `HttpClient` instance you provide to the `AnthropicApiClient` constructor.
-
-```csharp
-using AnthropicClient;
-
-var httpClient = new HttpClient();
-httpClient.DefaultRequestHeaders.Add("anthropic-beta", "pdfs-2024-09-25");
-
-var client = new AnthropicApiClient(apiKey, httpClient);
-```
+Anthropic provides a feature called [PDF Support](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support) that allows Claude to support PDF input and understand both text and visual content within documents. This feature is covered in depth in [Anthropic's API Documentation](https://docs.anthropic.com/en/docs/build-with-claude/pdf-support).
 
 PDF support can be used to provide a PDF document as input to the model. This can be used to provide additional context to the model or to ask for additional information from the model. This library aims to make using PDF support convenient by allowing you to provide the PDF document you want Anthropic's models to consider for use when creating a message.
 
@@ -884,11 +854,6 @@ var request = new MessageRequest(
     new(MessageRole.User, [new DocumentContent("application/pdf", base64Data)])
   ]
 );
-
-var httpClient = new HttpClient();
-httpClient.DefaultRequestHeaders.Add("anthropic-beta", "pdfs-2024-09-25");
-
-var client = new AnthropicApiClient(apiKey, httpClient);
 
 var response = await client.CreateMessageAsync(request);
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,38 @@ The primary use case for working with the Anthropic API is to create a message i
 > [!NOTE]
 > The following examples assume that you have already created an instance of the `AnthropicApiClient` class named `client`. You can also find these snippets in the examples directory.
 
+### Count Message Tokens
+
+The `AnthropicApiClient` exposes a method named `CountMessageTokensAsync` that can be used to count the number of tokens in a message. The method requires a `CountMessageTokensRequest` instance as a parameter.
+
+```csharp
+using AnthropicClient;
+using AnthropicClient.Models;
+
+var response = await client.CountMessageTokensAsync(new CountMessageTokensRequest(
+  AnthropicModels.Claude3Haiku,
+  [
+    new(
+      MessageRole.User, 
+      [new TextContent("Please write a haiku about the ocean.")]
+    )
+  ]
+));
+
+if (response.IsFailure)
+{
+  Console.WriteLine("Failed to count message tokens");
+  Console.WriteLine("Error Type: {0}", response.Error.Error.Type);
+  Console.WriteLine("Error Message: {0}", response.Error.Error.Message);
+  return;
+}
+
+Console.WriteLine("Token Count: {0}", response.Value.InputTokens);
+```
+
 ### Create a message
 
-The `AnthropicApiClient` exposes a single method named `CreateMessageAsync` that can be used to create a message. The method requires a `MessageRequest` or a `StreamMessageRequest` instance as a parameter. The `MessageRequest` class is used to create a message whose response is not streamed and the `StreamMessageRequest` class is used to create a message whose response is streamed. The `MessageRequest` instance's properties can be set to configure how the message is created.
+The `AnthropicApiClient` exposes a method named `CreateMessageAsync` that can be used to create a message. The method requires a `MessageRequest` or a `StreamMessageRequest` instance as a parameter. The `MessageRequest` class is used to create a message whose response is not streamed and the `StreamMessageRequest` class is used to create a message whose response is streamed. The `MessageRequest` instance's properties can be set to configure how the message is created.
 
 #### Non-Streaming
 

--- a/src/AnthropicClient/AnthropicApiClient.cs
+++ b/src/AnthropicClient/AnthropicApiClient.cs
@@ -26,6 +26,13 @@ public interface IAnthropicApiClient
   /// <param name="request">The message request to create.</param>
   /// <returns>An asynchronous enumerable that yields the response event by event.</returns>
   IAsyncEnumerable<AnthropicEvent> CreateMessageAsync(StreamMessageRequest request);
+
+  /// <summary>
+  /// Counts the tokens in a message asynchronously.
+  /// </summary>
+  /// <param name="request">The count message tokens request.</param>
+  /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="TokenCountResponse"/>.</returns>
+  Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request);
 }
 
 /// <inheritdoc cref="IAnthropicApiClient"/>
@@ -34,6 +41,7 @@ public class AnthropicApiClient : IAnthropicApiClient
   private const string BaseUrl = "https://api.anthropic.com/v1/";
   private const string ApiKeyHeader = "x-api-key";
   private const string MessagesEndpoint = "messages";
+  private const string CountTokensEndpoint = "messages/count_tokens";
   private const string JsonContentType = "application/json";
   private const string EventPrefix = "event:";
   private const string DataPrefix = "data:";
@@ -71,7 +79,7 @@ public class AnthropicApiClient : IAnthropicApiClient
   /// <inheritdoc />
   public async Task<AnthropicResult<MessageResponse>> CreateMessageAsync(MessageRequest request)
   {
-    var response = await SendRequestAsync(request);
+    var response = await SendRequestAsync(MessagesEndpoint, request);
     var anthropicHeaders = new AnthropicHeaders(response.Headers);
     var responseContent = await response.Content.ReadAsStringAsync();
 
@@ -94,7 +102,7 @@ public class AnthropicApiClient : IAnthropicApiClient
   /// <inheritdoc />
   public async IAsyncEnumerable<AnthropicEvent> CreateMessageAsync(StreamMessageRequest request)
   {
-    var response = await SendRequestAsync(request);
+    var response = await SendRequestAsync(MessagesEndpoint, request);
 
     if (response.IsSuccessStatusCode is false)
     {
@@ -274,11 +282,29 @@ public class AnthropicApiClient : IAnthropicApiClient
     return new ToolCall(tool, toolUse);
   }
 
-  private async Task<HttpResponseMessage> SendRequestAsync(BaseMessageRequest request)
+  /// <inheritdoc />
+  public async Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request)
+  {
+    var response = await SendRequestAsync(CountTokensEndpoint, request);
+    var anthropicHeaders = new AnthropicHeaders(response.Headers);
+    var responseContent = await response.Content.ReadAsStringAsync();
+
+    if (response.IsSuccessStatusCode is false)
+    {
+      var error = Deserialize<AnthropicError>(responseContent) ?? new AnthropicError();
+      return AnthropicResult<TokenCountResponse>.Failure(error, anthropicHeaders);
+    }
+
+    var msgResponse = Deserialize<TokenCountResponse>(responseContent) ?? new TokenCountResponse();
+
+    return AnthropicResult<TokenCountResponse>.Success(msgResponse, anthropicHeaders);
+  }
+
+  private async Task<HttpResponseMessage> SendRequestAsync<T>(string endpoint, T request)
   {
     var requestJson = Serialize(request);
     var requestContent = new StringContent(requestJson, Encoding.UTF8, JsonContentType);
-    return await _httpClient.PostAsync(MessagesEndpoint, requestContent);
+    return await _httpClient.PostAsync(endpoint, requestContent);
   }
 
   private string Serialize<T>(T obj) => JsonSerializer.Serialize(obj, JsonSerializationOptions.DefaultOptions);

--- a/src/AnthropicClient/Models/AnthropicModels.cs
+++ b/src/AnthropicClient/Models/AnthropicModels.cs
@@ -69,21 +69,4 @@ public static class AnthropicModels
   /// The Claude 3.5 Haiku model.
   /// </summary>
   public const string Claude35HaikuLatest = "claude-3-5-haiku-latest";
-
-  internal static bool IsValidModel(string modelId) => modelId is
-    Claude3Opus or
-    Claude3Opus20241022 or
-    Claude3OpusLatest or
-
-    Claude3Sonnet or
-    Claude3Sonnet20240229 or
-    Claude35Sonnet or
-    Claude35Sonnet20240620 or
-    Claude35Sonnet20241022 or
-    Claude35SonnetLatest or
-
-    Claude3Haiku or
-    Claude3Haiku20240307 or
-    Claude35Haiku20241022 or
-    Claude35HaikuLatest;
 }

--- a/src/AnthropicClient/Models/BaseMessageRequest.cs
+++ b/src/AnthropicClient/Models/BaseMessageRequest.cs
@@ -126,7 +126,6 @@ public abstract class BaseMessageRequest
   /// <param name="stream">A value indicating whether the message should be streamed.</param>
   /// <param name="stopSequences">The prompt stop sequences.</param>
   /// <param name="systemMessages">The system messages to use for the request.</param>
-  /// <exception cref="ArgumentException">Thrown when the model ID is invalid.</exception>
   /// <exception cref="ArgumentNullException">Thrown when the model or messages is null.</exception>
   /// <exception cref="ArgumentException">Thrown when the messages contain no messages.</exception>
   /// <exception cref="ArgumentException">Thrown when the max tokens is less than one.</exception>
@@ -150,11 +149,6 @@ public abstract class BaseMessageRequest
   {
     ArgumentValidator.ThrowIfNull(model, nameof(model));
     ArgumentValidator.ThrowIfNull(messages, nameof(messages));
-
-    if (AnthropicModels.IsValidModel(model) is false)
-    {
-      throw new ArgumentException($"Invalid model ID: {model}");
-    }
 
     if (messages.Count < 1)
     {

--- a/src/AnthropicClient/Models/CountMessageTokensRequest.cs
+++ b/src/AnthropicClient/Models/CountMessageTokensRequest.cs
@@ -1,0 +1,72 @@
+using System.Text.Json.Serialization;
+
+using AnthropicClient.Utils;
+
+namespace AnthropicClient.Models;
+
+/// <summary>
+/// Represents a request to count the number of tokens in a message.
+/// </summary>
+public class CountMessageTokensRequest
+{
+  /// <summary>
+  /// Gets the model ID to be used for the request.
+  /// </summary>
+  public string Model { get; init; } = string.Empty;
+
+  /// <summary>
+  /// Gets the messages to count the number of tokens in.
+  /// </summary>
+  public List<Message> Messages { get; init; } = [];
+
+  /// <summary>
+  /// Gets the tool choice mode to use for the request.
+  /// </summary>
+  [JsonPropertyName("tool_choice")]
+  public ToolChoice? ToolChoice { get; init; } = null;
+
+  /// <summary>
+  /// Gets the tools to use for the request.
+  /// </summary>
+  public List<Tool>? Tools { get; init; } = null;
+
+  /// <summary>
+  /// Gets the system prompt to use for the request.
+  /// </summary>
+  [JsonPropertyName("system")]
+  public List<TextContent>? SystemPrompt { get; init; } = null;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="CountMessageTokensRequest"/> class.
+  /// </summary>
+  /// <param name="model">The model ID to use for the request.</param>
+  /// <param name="messages">The messages to count the number of tokens in.</param>
+  /// <param name="toolChoice">The tool choice mode to use for the request.</param>
+  /// <param name="tools">The tools to use for the request.</param>
+  /// <param name="systemPrompt">The system prompt to use for the request.</param>
+  /// <exception cref="ArgumentNullException">Thrown when <paramref name="model"/> or <paramref name="messages"/> is null.</exception>
+  /// <exception cref="ArgumentException">Thrown when <paramref name="messages"/> is empty.</exception>
+  /// <returns>A new instance of the <see cref="CountMessageTokensRequest"/> class.</returns>
+  public CountMessageTokensRequest(
+    string model,
+    List<Message> messages,
+    ToolChoice? toolChoice = null,
+    List<Tool>? tools = null,
+    List<TextContent>? systemPrompt = null
+  )
+  {
+    ArgumentValidator.ThrowIfNull(model, nameof(model));
+    ArgumentValidator.ThrowIfNull(messages, nameof(messages));
+
+    if (messages.Count < 1)
+    {
+      throw new ArgumentException("Messages must contain at least one message");
+    }
+
+    Model = model;
+    Messages = messages;
+    ToolChoice = toolChoice;
+    Tools = tools;
+    SystemPrompt = systemPrompt;
+  }
+}

--- a/src/AnthropicClient/Models/MessageRequest.cs
+++ b/src/AnthropicClient/Models/MessageRequest.cs
@@ -25,7 +25,6 @@ public class MessageRequest : BaseMessageRequest
   /// <param name="tools">The tools to use for the request.</param>
   /// <param name="stopSequences">The prompt stop sequences.</param>
   /// <param name="systemMessages">The system messages to include with the request.</param>
-  /// <exception cref="ArgumentException">Thrown when the model ID is invalid.</exception>
   /// <exception cref="ArgumentNullException">Thrown when the model or messages is null.</exception>
   /// <exception cref="ArgumentException">Thrown when the messages contain no messages.</exception>
   /// <exception cref="ArgumentException">Thrown when the max tokens is less than one.</exception>

--- a/src/AnthropicClient/Models/StreamMessageRequest.cs
+++ b/src/AnthropicClient/Models/StreamMessageRequest.cs
@@ -25,7 +25,6 @@ public class StreamMessageRequest : BaseMessageRequest
   /// <param name="tools">The tools to use for the request.</param>
   /// <param name="stopSequences">The prompt stop sequences.</param>
   /// <param name="systemMessages">The system messages to include with the request.</param>
-  /// <exception cref="ArgumentException">Thrown when the model ID is invalid.</exception>
   /// <exception cref="ArgumentNullException">Thrown when the model or messages is null.</exception>
   /// <exception cref="ArgumentException">Thrown when the messages contain no messages.</exception>
   /// <exception cref="ArgumentException">Thrown when the max tokens is less than one.</exception>

--- a/src/AnthropicClient/Models/TokenCountResponse.cs
+++ b/src/AnthropicClient/Models/TokenCountResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace AnthropicClient.Models;
+
+/// <summary>
+/// Represents a response to a token count request.
+/// </summary>
+public class TokenCountResponse
+{
+  /// <summary>
+  ///  The number of input tokens counted.
+  /// </summary>
+  [JsonPropertyName("input_tokens")]
+  public int InputTokens { get; init; }
+}

--- a/tests/AnthropicClient.Tests/EndToEnd/AnthropicApiClientTests.cs
+++ b/tests/AnthropicClient.Tests/EndToEnd/AnthropicApiClientTests.cs
@@ -299,4 +299,21 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
     resultTwo.Value.Content.Should().NotBeNullOrEmpty();
     resultTwo.Value.Usage.CacheReadInputTokens.Should().BeGreaterThan(0);
   }
+
+  [Fact]
+  public async Task CountMessageTokensAsync_WhenCalled_ItShouldReturnResponse()
+  {
+    var request = new CountMessageTokensRequest(
+      model: AnthropicModels.Claude3Haiku,
+      messages: [
+        new(MessageRole.User, [new TextContent("Hello!")])
+      ]
+    );
+
+    var result = await _client.CountMessageTokensAsync(request);
+
+    result.IsSuccess.Should().BeTrue();
+    result.Value.Should().BeOfType<TokenCountResponse>();
+    result.Value.InputTokens.Should().BeGreaterThan(0);
+  }
 }

--- a/tests/AnthropicClient.Tests/EndToEnd/AnthropicApiClientTests.cs
+++ b/tests/AnthropicClient.Tests/EndToEnd/AnthropicApiClientTests.cs
@@ -100,10 +100,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
   [Fact]
   public async Task CreateMessageAsync_WhenSystemMessagesContainCacheControl_ItShouldUseCache()
   {
-    var httpClient = new HttpClient();
-    httpClient.DefaultRequestHeaders.Add("anthropic-beta", "prompt-caching-2024-07-31");
-
-    var client = CreateClient(httpClient);
+    var client = CreateClient(new HttpClient());
 
     var storyPath = GetTestFilePath("story.txt");
     var storyText = await File.ReadAllTextAsync(storyPath);
@@ -121,7 +118,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
       ]
     );
 
-    var resultOne = await client.CreateMessageAsync(request);
+    var resultOne = await _client.CreateMessageAsync(request);
 
     resultOne.IsSuccess.Should().BeTrue();
     resultOne.Value.Should().BeOfType<MessageResponse>();
@@ -142,10 +139,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
   [Fact]
   public async Task CreateMessageAsync_WhenMessagesContainCacheControl_ItShouldUseCache()
   {
-    var httpClient = new HttpClient();
-    httpClient.DefaultRequestHeaders.Add("anthropic-beta", "prompt-caching-2024-07-31");
-
-    var client = CreateClient(httpClient);
+    var client = CreateClient(new HttpClient());
 
     var storyPath = GetTestFilePath("story.txt");
     var storyText = await File.ReadAllTextAsync(storyPath);
@@ -181,10 +175,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
   [Fact]
   public async Task CreateMessageAsync_WhenToolsContainCacheControl_ItShouldUseCache()
   {
-    var httpClient = new HttpClient();
-    httpClient.DefaultRequestHeaders.Add("anthropic-beta", "prompt-caching-2024-07-31");
-
-    var client = CreateClient(httpClient);
+    var client = CreateClient(new HttpClient());
 
     var func = (string ticker) => ticker;
 
@@ -238,9 +229,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
       ]
     );
 
-    var httpClient = new HttpClient();
-    httpClient.DefaultRequestHeaders.Add("anthropic-beta", "pdfs-2024-09-25");
-    var client = CreateClient(httpClient);
+    var client = CreateClient(new HttpClient());
 
     var result = await client.CreateMessageAsync(request);
 
@@ -268,9 +257,7 @@ public class ClientTests(ConfigurationFixture configFixture) : EndToEndTest(conf
     var bytes = await File.ReadAllBytesAsync(pdfPath);
     var base64Data = Convert.ToBase64String(bytes);
 
-    var httpClient = new HttpClient();
-    httpClient.DefaultRequestHeaders.Add("anthropic-beta", "pdfs-2024-09-25, prompt-caching-2024-07-31");
-    var client = CreateClient(httpClient);
+    var client = CreateClient(new HttpClient());
 
     var request = new MessageRequest(
       model: AnthropicModels.Claude35Sonnet,

--- a/tests/AnthropicClient.Tests/Integration/IntegrationTest.cs
+++ b/tests/AnthropicClient.Tests/Integration/IntegrationTest.cs
@@ -13,10 +13,18 @@ public class IntegrationTest
 
 public static class MockHttpMessageHandlerExtensions
 {
-  private static MockedRequest SetupBaseRequest(this MockHttpMessageHandler mockHttpMessageHandler)
+  private const string BaseUrl = "https://api.anthropic.com/v1";
+  private static readonly string MessagesEndpoint = $"{BaseUrl}/messages";
+  private static readonly string CountTokensEndpoint = $"{BaseUrl}/messages/count_tokens";
+
+  private static MockedRequest SetupBaseRequest(
+    this MockHttpMessageHandler mockHttpMessageHandler,
+    HttpMethod method,
+    string url
+  )
   {
     return mockHttpMessageHandler
-      .When(HttpMethod.Post, "https://api.anthropic.com/v1/messages")
+      .When(method, url)
       .WithHeaders(new Dictionary<string, string>
       {
         { "anthropic-version", "2023-06-01" },
@@ -27,14 +35,20 @@ public static class MockHttpMessageHandlerExtensions
   public static MockedRequest WhenCreateMessageRequest(this MockHttpMessageHandler mockHttpMessageHandler)
   {
     return mockHttpMessageHandler
-      .SetupBaseRequest()
+      .SetupBaseRequest(HttpMethod.Post, MessagesEndpoint)
       .WithJsonContent<MessageRequest>(r => r.Stream == false, JsonSerializationOptions.DefaultOptions);
   }
 
   public static MockedRequest WhenCreateStreamMessageRequest(this MockHttpMessageHandler mockHttpMessageHandler)
   {
     return mockHttpMessageHandler
-      .SetupBaseRequest()
+      .SetupBaseRequest(HttpMethod.Post, MessagesEndpoint)
       .WithJsonContent<StreamMessageRequest>(r => r.Stream == true, JsonSerializationOptions.DefaultOptions);
+  }
+
+  public static MockedRequest WhenCountMessageTokensRequest(this MockHttpMessageHandler mockHttpMessageHandler)
+  {
+    return mockHttpMessageHandler
+      .SetupBaseRequest(HttpMethod.Post, CountTokensEndpoint);
   }
 }

--- a/tests/AnthropicClient.Tests/Unit/Models/AnthropicModelsTests.cs
+++ b/tests/AnthropicClient.Tests/Unit/Models/AnthropicModelsTests.cs
@@ -131,22 +131,4 @@ public class AnthropicModelsTests
 
     actual.Should().Be(expected);
   }
-
-  [Theory]
-  [InlineData("claude-3-opus-20240229", true)]
-  [InlineData("claude-3-opus-latest", true)]
-  [InlineData("claude-3-sonnet-20240229", true)]
-  [InlineData("claude-3-5-sonnet-20240620", true)]
-  [InlineData("claude-3-5-sonnet-20241022", true)]
-  [InlineData("claude-3-5-sonnet-latest", true)]
-  [InlineData("claude-3-haiku-20240307", true)]
-  [InlineData("claude-3-5-haiku-20241022", true)]
-  [InlineData("claude-3-5-haiku-latest", true)]
-  [InlineData("invalid", false)]
-  public void IsValidModel_WhenCalled_ItShouldReturnExpectedValue(string modelId, bool expected)
-  {
-    var actual = AnthropicModels.IsValidModel(modelId);
-
-    actual.Should().Be(expected);
-  }
 }

--- a/tests/AnthropicClient.Tests/Unit/Models/CountMessageTokensRequestTests.cs
+++ b/tests/AnthropicClient.Tests/Unit/Models/CountMessageTokensRequestTests.cs
@@ -1,0 +1,117 @@
+namespace AnthropicClient.Tests.Unit.Models;
+
+public class CountMessageTokensRequestTests : SerializationTest
+{
+  private readonly string _testJson = @"{
+    ""model"": ""claude-3-sonnet-20240229"",
+    ""system"": [{
+      ""type"": ""text"",
+      ""text"": ""test-system""
+    }],
+    ""messages"": [
+      { ""role"": ""user"", ""content"": [{ ""text"": ""Hello!"", ""type"": ""text"" }] }
+    ],
+    ""tool_choice"": { ""type"":""auto"" },
+    ""tools"": []
+  }";
+
+  [Fact]
+  public void Constructor_WhenCalled_ItShouldInitializeProperties()
+  {
+    var model = AnthropicModels.Claude3Sonnet;
+    var messages = new List<Message> { new() };
+    var systemPrompt = new List<TextContent>() { new("test-system") };
+    var toolChoice = new AutoToolChoice();
+    var tools = new List<Tool>();
+
+    var request = new CountMessageTokensRequest(
+      model: model,
+      messages: messages,
+      toolChoice: toolChoice,
+      tools: tools,
+      systemPrompt: systemPrompt
+    );
+
+    request.Model.Should().Be(model);
+    request.Messages.Should().BeSameAs(messages);
+    request.ToolChoice.Should().Be(toolChoice);
+    request.Tools.Should().BeSameAs(tools);
+    request.SystemPrompt.Should().BeSameAs(systemPrompt);
+  }
+
+  [Fact]
+  public void Constructor_WhenCalledAndModelIsNull_ItShouldThrowArgumentNullException()
+  {
+    var action = () => new CountMessageTokensRequest(
+      model: null!,
+      messages: [new()]
+    );
+
+    action.Should().Throw<ArgumentNullException>();
+  }
+
+  [Fact]
+  public void Constructor_WhenCalledAndMessagesIsNull_ItShouldThrowArgumentNullException()
+  {
+    var action = () => new CountMessageTokensRequest(
+      model: AnthropicModels.Claude3Sonnet,
+      messages: null!
+    );
+
+    action.Should().Throw<ArgumentNullException>();
+  }
+
+  [Fact]
+  public void Constructor_WhenCalledAndMessagesIsEmpty_ItShouldThrowArgumentException()
+  {
+    var action = () => new CountMessageTokensRequest(
+      model: AnthropicModels.Claude3Sonnet,
+      messages: []
+    );
+
+    action.Should().Throw<ArgumentException>();
+  }
+
+  [Fact]
+  public void JsonSerialization_WhenSerialized_ItShouldHaveExpectedShape()
+  {
+    var messages = new List<Message>()
+    {
+      new()
+      {
+        Role = MessageRole.User,
+        Content = [new TextContent("Hello!")]
+      }
+    };
+
+    var model = AnthropicModels.Claude3Sonnet;
+    var systemPrompt = new List<TextContent>() { new("test-system") };
+    var toolChoice = new AutoToolChoice();
+    var tools = new List<Tool>();
+
+    var request = new CountMessageTokensRequest(
+      model: model,
+      messages: messages,
+      toolChoice: toolChoice,
+      tools: tools,
+      systemPrompt: systemPrompt
+    );
+
+    var actual = Serialize(request);
+
+    JsonAssert.Equal(_testJson, actual);
+  }
+
+  [Fact]
+  public void JsonDeserialization_WhenDeserialized_ItShouldHaveExpectedShape()
+  {
+    var request = Deserialize<CountMessageTokensRequest>(_testJson);
+
+    request!.Model.Should().Be(AnthropicModels.Claude3Sonnet);
+    request.SystemPrompt.Should().BeEquivalentTo(new List<TextContent> { new("test-system") });
+    request.Messages.Should().HaveCount(1);
+    request.ToolChoice.Should().BeOfType<AutoToolChoice>();
+    request.ToolChoice!.Type.Should().Be("auto");
+    request.Tools.Should().HaveCount(0);
+  }
+}

--- a/tests/AnthropicClient.Tests/Unit/Models/MessageRequestTests.cs
+++ b/tests/AnthropicClient.Tests/Unit/Models/MessageRequestTests.cs
@@ -232,14 +232,14 @@ public class MessageRequestTests : SerializationTest
   }
 
   [Fact]
-  public void Constructor_WhenCalledAndModelIsInvalid_ItShouldThrowArgumentException()
+  public void Constructor_WhenCalledAndModelIsInvalid_ItShouldNotThrowException()
   {
     var action = () => new MessageRequest(
       model: "invalid-model",
       messages: [new()]
     );
 
-    action.Should().Throw<ArgumentException>();
+    action.Should().NotThrow();
   }
 
   [Fact]

--- a/tests/AnthropicClient.Tests/Unit/Models/StreamMessageRequestTests.cs
+++ b/tests/AnthropicClient.Tests/Unit/Models/StreamMessageRequestTests.cs
@@ -85,14 +85,14 @@ public class StreamMessageRequestTests : SerializationTest
   }
 
   [Fact]
-  public void Constructor_WhenCalledAndModelIsInvalid_ItShouldThrowArgumentException()
+  public void Constructor_WhenCalledAndModelIsInvalid_ItShouldNotThrowException()
   {
     var action = () => new StreamMessageRequest(
       model: "invalid-model",
       messages: [new()]
     );
 
-    action.Should().Throw<ArgumentException>();
+    action.Should().NotThrow();
   }
 
   [Fact]

--- a/tests/AnthropicClient.Tests/Unit/Models/TokenCountResponseTests.cs
+++ b/tests/AnthropicClient.Tests/Unit/Models/TokenCountResponseTests.cs
@@ -1,0 +1,46 @@
+namespace AnthropicClient.Tests.Unit.Models;
+
+public class TokenCountResponseTests : SerializationTest
+{
+  [Fact]
+  public void Constructor_WhenCalled_ShouldInitializeProperties()
+  {
+    var expectedTokenCount = 1;
+
+    var response = new TokenCountResponse
+    {
+      InputTokens = expectedTokenCount
+    };
+
+    response.InputTokens.Should().Be(expectedTokenCount);
+  }
+
+  [Fact]
+  public void JsonSerialization_WhenCalled_ItShouldSerializeCorrectly()
+  {
+    var expectedJson = @"{
+      ""input_tokens"": 1
+    }";
+
+    var response = new TokenCountResponse
+    {
+      InputTokens = 1
+    };
+
+    var actual = Serialize(response);
+
+    JsonAssert.Equal(expectedJson, actual);
+  }
+
+  [Fact]
+  public void JsonDeserialization_WhenCalled_ItShouldDeserializeCorrectly()
+  {
+    var json = @"{
+      ""input_tokens"": 1
+    }";
+
+    var response = Deserialize<TokenCountResponse>(json);
+
+    response!.InputTokens.Should().Be(1);
+  }
+}


### PR DESCRIPTION
closes #19
closes #25

- **fix: remove model id validation**
- **feat: add support for count tokens endpoint**
- **refactor: put public method above private methods**
- **tests: add integration tests to cover both 😁 and 🥲 paths when counting message tokens**
- **chore: remove need for beta header when using prompt caching or PDF support**
- **docs: add count message tokens example to README.md**
