### PR TITLE
fix: add cancellation token support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.ACTIONS_PAT }}
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Install versionize
         run: dotnet tool install --global Versionize
       - name: Setup git
@@ -53,10 +53,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
           token: ${{ secrets.ACTIONS_PAT }}
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Get project version
         uses: kzrnm/get-net-sdk-project-versions-action@v1
         id: get-version
@@ -88,10 +88,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
           token: ${{ secrets.ACTIONS_PAT }}
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Install Docfx
         run: dotnet tool install --global docfx
       - name: Get project version

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Format code
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup .NET 8
+      - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Install report generator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.3.7
       - name: Restore dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,18 @@
   "dotnet.defaultSolution": "AnthropicClient.sln",
   "cSpell.words": [
     "Browsable",
+    "buildtransitive",
+    "contentfiles",
+    "Docfx",
+    "globaltool",
     "haikus",
+    "Linq",
+    "msbuild",
     "nameof",
+    "reportgenerator",
+    "reporttypes",
     "Szalay",
+    "targetdir",
     "typeof"
   ],
   "dotnet.unitTests.runSettingsPath": "./tests/AnthropicClient.Tests/.runsettings"

--- a/src/AnthropicClient/AnthropicApiClient.cs
+++ b/src/AnthropicClient/AnthropicApiClient.cs
@@ -303,7 +303,7 @@ public class AnthropicApiClient : IAnthropicApiClient
 
     return AnthropicResult<IAsyncEnumerable<MessageBatchResultItem>>.Success(ReadResultsAsync(), anthropicHeaders);
 
-    async IAsyncEnumerable<MessageBatchResultItem> ReadResultsAsync([EnumeratorCancellation] CancellationToken ct = default)
+    async IAsyncEnumerable<MessageBatchResultItem> ReadResultsAsync()
     {
       using var responseContent = await response.Content.ReadAsStreamAsync();
       using var streamReader = new StreamReader(responseContent);

--- a/src/AnthropicClient/AnthropicClient.csproj
+++ b/src/AnthropicClient/AnthropicClient.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/AnthropicClient/IAnthropicApiClient.cs
+++ b/src/AnthropicClient/IAnthropicApiClient.cs
@@ -96,7 +96,7 @@ public interface IAnthropicApiClient
   Task<AnthropicResult<Page<AnthropicModel>>> ListModelsAsync(PagingRequest? request = null, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Lists the model asynchronously getting all the pages of models.
+  /// Lists all models asynchronously, returning every page of results.
   /// </summary>
   /// <param name="limit">The maximum number of models to return in each page.</param>
   /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>

--- a/src/AnthropicClient/IAnthropicApiClient.cs
+++ b/src/AnthropicClient/IAnthropicApiClient.cs
@@ -88,7 +88,7 @@ public interface IAnthropicApiClient
   Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Lists the models asynchronously getting a page of models.
+  /// Lists models asynchronously, returning a single page of results.
   /// </summary>
   /// <param name="request">The paging request to use for listing the models.</param>
   /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>

--- a/src/AnthropicClient/IAnthropicApiClient.cs
+++ b/src/AnthropicClient/IAnthropicApiClient.cs
@@ -11,91 +11,104 @@ public interface IAnthropicApiClient
   /// Creates a message asynchronously.
   /// </summary>
   /// <param name="request">The message request to create.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/>.</returns>
-  Task<AnthropicResult<MessageResponse>> CreateMessageAsync(MessageRequest request);
+  Task<AnthropicResult<MessageResponse>> CreateMessageAsync(MessageRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Creates a message asynchronously and streams the response.
   /// </summary>
   /// <param name="request">The message request to create.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>An asynchronous enumerable that yields the response event by event.</returns>
-  IAsyncEnumerable<AnthropicEvent> CreateMessageAsync(StreamMessageRequest request);
+  IAsyncEnumerable<AnthropicEvent> CreateMessageAsync(StreamMessageRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Creates a batch of messages asynchronously.
   /// </summary>
   /// <param name="request">The message batch request to create.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="MessageBatchResponse"/>.</returns>
-  Task<AnthropicResult<MessageBatchResponse>> CreateMessageBatchAsync(MessageBatchRequest request);
+  Task<AnthropicResult<MessageBatchResponse>> CreateMessageBatchAsync(MessageBatchRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Gets a message batch asynchronously.
   /// </summary>
   /// <param name="batchId">The ID of the message batch to get.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="MessageBatchResponse"/>.</returns>
-  Task<AnthropicResult<MessageBatchResponse>> GetMessageBatchAsync(string batchId);
+  Task<AnthropicResult<MessageBatchResponse>> GetMessageBatchAsync(string batchId, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Lists the message batches asynchronously.
   /// </summary>
   /// <param name="request">The paging request to use for listing the message batches.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="Page{T}"/> where T is <see cref="MessageBatchResponse"/>.</returns>
-  Task<AnthropicResult<Page<MessageBatchResponse>>> ListMessageBatchesAsync(PagingRequest? request = null);
+  Task<AnthropicResult<Page<MessageBatchResponse>>> ListMessageBatchesAsync(PagingRequest? request = null, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Lists all message batches asynchronously.
   /// </summary>
   /// <param name="limit">The maximum number of message batches to return in each page.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>An asynchronous enumerable that yields the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="Page{T}"/> where T is <see cref="MessageBatchResponse"/>.</returns>
-  IAsyncEnumerable<AnthropicResult<Page<MessageBatchResponse>>> ListAllMessageBatchesAsync(int limit = 20);
+  IAsyncEnumerable<AnthropicResult<Page<MessageBatchResponse>>> ListAllMessageBatchesAsync(int limit = 20, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Cancels a message batch asynchronously.
   /// </summary>
   /// <param name="batchId">The ID of the message batch to cancel.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="MessageBatchResponse"/>.</returns>
-  Task<AnthropicResult<MessageBatchResponse>> CancelMessageBatchAsync(string batchId);
+  Task<AnthropicResult<MessageBatchResponse>> CancelMessageBatchAsync(string batchId, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Deletes a message batch asynchronously.
   /// </summary>
   /// <param name="batchId">The ID of the message batch to delete.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="MessageBatchDeleteResponse"/>.</returns>
-  Task<AnthropicResult<MessageBatchDeleteResponse>> DeleteMessageBatchAsync(string batchId);
+  Task<AnthropicResult<MessageBatchDeleteResponse>> DeleteMessageBatchAsync(string batchId, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Gets the results of a message batch asynchronously.
   /// </summary>
   /// <param name="batchId">The ID of the message batch to get the results for.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="IAsyncEnumerable{T}"/> where T is <see cref="MessageBatchResultItem"/>.</returns>
-  Task<AnthropicResult<IAsyncEnumerable<MessageBatchResultItem>>> GetMessageBatchResultsAsync(string batchId);
+  Task<AnthropicResult<IAsyncEnumerable<MessageBatchResultItem>>> GetMessageBatchResultsAsync(string batchId, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Counts the tokens in a message asynchronously.
   /// </summary>
   /// <param name="request">The count message tokens request.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="TokenCountResponse"/>.</returns>
-  Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request);
+  Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Lists the models asynchronously.
   /// </summary>
   /// <param name="request">The paging request to use for listing the models.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="Page{T}"/> where T is <see cref="AnthropicModel"/>.</returns>
-  Task<AnthropicResult<Page<AnthropicModel>>> ListModelsAsync(PagingRequest? request = null);
+  Task<AnthropicResult<Page<AnthropicModel>>> ListModelsAsync(PagingRequest? request = null, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Lists the models asynchronously
   /// </summary>
   /// <param name="limit">The maximum number of models to return in each page.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>An asynchronous enumerable that yields the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="Page{T}"/> where T is <see cref="AnthropicModel"/>.</returns>
   /// 
-  IAsyncEnumerable<AnthropicResult<Page<AnthropicModel>>> ListAllModelsAsync(int limit = 20);
+  IAsyncEnumerable<AnthropicResult<Page<AnthropicModel>>> ListAllModelsAsync(int limit = 20, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Gets a model by its ID asynchronously.
   /// </summary>
   /// <param name="modelId">The ID of the model to get.</param>
+  /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
   /// <returns>A task that represents the asynchronous operation. The task result contains the response as an <see cref="AnthropicResult{T}"/> where T is <see cref="AnthropicModel"/>.</returns>
-  Task<AnthropicResult<AnthropicModel>> GetModelAsync(string modelId);
+  Task<AnthropicResult<AnthropicModel>> GetModelAsync(string modelId, CancellationToken cancellationToken = default);
 }

--- a/src/AnthropicClient/IAnthropicApiClient.cs
+++ b/src/AnthropicClient/IAnthropicApiClient.cs
@@ -88,7 +88,7 @@ public interface IAnthropicApiClient
   Task<AnthropicResult<TokenCountResponse>> CountMessageTokensAsync(CountMessageTokensRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Lists the models asynchronously.
+  /// Lists the models asynchronously getting a page of models.
   /// </summary>
   /// <param name="request">The paging request to use for listing the models.</param>
   /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -96,7 +96,7 @@ public interface IAnthropicApiClient
   Task<AnthropicResult<Page<AnthropicModel>>> ListModelsAsync(PagingRequest? request = null, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Lists the models asynchronously
+  /// Lists the model asynchronously getting all the pages of models.
   /// </summary>
   /// <param name="limit">The maximum number of models to return in each page.</param>
   /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>

--- a/tests/AnthropicClient.Tests/AnthropicClient.Tests.csproj
+++ b/tests/AnthropicClient.Tests/AnthropicClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -54,7 +54,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="Files/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/AnthropicClient.Tests/AnthropicClient.Tests.csproj
+++ b/tests/AnthropicClient.Tests/AnthropicClient.Tests.csproj
@@ -10,21 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
closes #33

- **fix: copilot first attempt**
- **fix: cleanup copilot mistakes with passing cancellation token to methods that don't accept them**
- **chore: upgrade test project to .NET 9**
- **chore: upgrade dependencies**
